### PR TITLE
Update the API for MercadoBitcoin's exchange rate.

### DIFF
--- a/lib/exchange_rate.py
+++ b/lib/exchange_rate.py
@@ -197,7 +197,7 @@ class OKCoin(ExchangeBase):
 class MercadoBitcoin(ExchangeBase):
     def get_rates(self,ccy):
         json = self.get_json('mercadobitcoin.net',
-                                "/api/ticker_litecoin")
+                                "/api/v2/ticker_litecoin")
         return {'BRL': Decimal(json['ticker']['last'])}
 
     def history_ccys(self):


### PR DESCRIPTION
The API for MercadoBitcoin changed recently. It must be updated from /api/ticker_litecoin to /api/v2/ticker_litecoin or will break.