### PR TITLE
Update OSX README.md

### DIFF
--- a/contrib/osx/README.md
+++ b/contrib/osx/README.md
@@ -58,7 +58,7 @@ These tools do not work on macOS, so you need a separate Linux machine (or VM).
 
 Copy the Electrum-LTC.app directory over and install the dependencies, e.g.:
 
-    apt install libcap-dev cmake make gcc faketime
+    apt install libcap-dev cmake make gcc faketime libbz2-dev
     
 Then you can just invoke `package.sh` with the path to the app:
 


### PR DESCRIPTION
When attempting the OSX deterministic build process on Ubuntu, I encountered the following issue;

```
/tmp/electrum-ltc-macos/cdrkit-1.1.11/genisoimage/jte.c:17:10: fatal error: bzlib.h: No such file or directory
 #include <bzlib.h>
          ^~~~~~~~~
```

This adds the required dependency to the readme and compilation succeeds without any issues.