### PR TITLE
Change name of user directory environment variable

### DIFF
--- a/electrum_ltc/util.py
+++ b/electrum_ltc/util.py
@@ -573,8 +573,8 @@ def xor_bytes(a: bytes, b: bytes) -> bytes:
 
 
 def user_dir():
-    if "ELECTRUMDIR" in os.environ:
-        return os.environ["ELECTRUMDIR"]
+    if "ELECTRUMLTC_DIR" in os.environ:
+        return os.environ["ELECTRUMLTC_DIR"]
     elif 'ANDROID_DATA' in os.environ:
         return android_data_dir()
     elif os.name == 'posix':


### PR DESCRIPTION
If the user has both Electrum and Electrum-LTC installed, and they have the environment variable `ELECTRUMDIR` set (e.g. to `~/.local/share/electrum`), then Electrum-LTC will place its user files in the same directory as Electrum, which can result in one program's config overwriting the other, as well as servers and wallets getting mixed together.

So this PR changes the name of the user directory environment variable to `ELECTRUMLTC_DIR` to avoid that confusion. 